### PR TITLE
Fix deploy function JSON parse error

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -167,7 +167,7 @@ const deployFunction = async () => {
                 functionId: func['$id'],
                 name: func.name,
                 execute: func.execute,
-                vars: response.vars,
+                vars: JSON.stringify(response.vars),
                 events: func.events,
                 schedule: func.schedule,
                 timeout: func.timeout,


### PR DESCRIPTION
JSON.stringify(response.vars) because vars should be a JSON string rather than object.

Closes: https://github.com/appwrite/appwrite/issues/3097